### PR TITLE
🚑 Exporting type declaration for typescript

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "lib": ["es2016", "dom"],
-    "sourceMap": true
+    "sourceMap": true,
+    "declaration": true
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
Caught an error that the type declaration was not exported properly, this prevents typescript users from having types when using the package.


Ps: Feel free to change my commit message, didn't have a contributing.md so just used gitmoji